### PR TITLE
Fix: Only post for games played on the previous day

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "atproto",
   "nba_api",
   "pandas",
+  "pytz",
 ]
 
 [project.urls]


### PR DESCRIPTION
The script was previously fetching the player's latest game and posting if its date matched my calculation of "yesterday". This led to incorrect posts when no game was played the previous day but an older game existed, potentially due to timezone mismatches or the definition of "latest game".

This commit refactors the game fetching logic:
- Uses `pytz` to reliably determine "yesterday" in US/Eastern timezone, where NBA schedules are typically based.
- Modifies `LeagueGameFinder` query to explicitly search for games played *only* on this calculated US/Eastern "yesterday".
- If a game is found for that specific date, a Bluesky post is made.
- If no game is found for that date, no post is made, and an informative message is logged.
- Removed the previous, less reliable date comparison logic.

This ensures that posts are only made if the player had a game on the immediately preceding day in the US/Eastern timezone.